### PR TITLE
add node_env as development in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     ports:
       - "4000:4000"
     environment:
+      - NODE_ENV=development
       - PRISMA_HOST=${PRISMA_HOST}
       - PRISMA_SECRET=${PRISMA_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
to ensure that phoenix recognises the environment as development
otherwise, it defaults to production when running inside a docker container